### PR TITLE
windows uses rn, and *nix-like uses n, so drop just r

### DIFF
--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -12,7 +12,7 @@ import { Disposable } from './utils/disposable';
 import { Event } from './utils/event';
 
 const DRIVE_LETTER_PATH_REGEX = /^[a-z]:\//;
-const EOL_REGEX = /\r\n|\r|\n/g;
+const EOL_REGEX = /\r\n|\n/g;
 const INVALID_BRANCH_REGEXP = /^\(.* .*\)$/;
 const REMOTE_HEAD_BRANCH_REGEXP = /^remotes\/.*\/HEAD$/;
 const GIT_LOG_SEPARATOR = 'XX7Nal-YARtTpjCikii9nJxER19D6diSyk-AWkPb';


### PR DESCRIPTION
https://github.com/mhutchie/vscode-git-graph/pull/644